### PR TITLE
prop-types package 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "istanbul": "^0.4.5",
     "jsdom": "^9.5.0",
     "mocha": "^3.0.2",
+    "prop-types": "^15.6.0",
     "react": "^15.0",
     "react-addons-shallow-compare": "^15.0",
     "react-addons-test-utils": "^15.0",

--- a/src/Async.js
+++ b/src/Async.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Select from './Select';
 import stripDiacritics from './utils/stripDiacritics';
 


### PR DESCRIPTION
prop-types 를 react 가 아닌 prop-types 패키지에서 로드하도록 수정한 PR 입니다.

```
import {PropTypes} from 'react';
```
위를 아래로 변경하였습니다.

```
import PropTypes from 'prop-types';
```

확인 후 반영 부탁드리겠습니다.

